### PR TITLE
Update post, fix minor typo

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-title: 
+title:
 subtitle: IPM Observational Astronomy Meetings (OAM)
 layout: page
 #callouts: home_callouts
@@ -11,9 +11,9 @@ hero_image: img/h1.jpg
 
 The OAM are now either in-person or hybrid.
 
-If you would like to attend virtually or in person, please get in touch with the organisers.
+If you would like to attend virtually or in person, please get in touch with the organizers.
 
-**Organisers:**
+**Organizers:**
 
 Elham Eftekhari (elhamea@ipm.ir)
 

--- a/presentations/2022/Working_in_Command-Line_Interface.md
+++ b/presentations/2022/Working_in_Command-Line_Interface.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: IPM-OAM presentation
-subtitle: 
+subtitle:
 #menubar: docs_menu
 show_sidebar: false
 #toc: true
@@ -15,7 +15,7 @@ show_sidebar: false
 چرا با وجود پیشرفت بسیار گرافیک دستگاه ها، محیط خط فرمان فراموش نشده؟
 آیا واقعا کار در محیط گرافیکی سریعتر از یادآوری و تایپ کردن دستور است؟
 پوسته و بش چه هستند؟
-آیا با وجود «پایتون» دیگر نیازی به «بش» هست؟
+آیا با وجود «پایتون[^1]» دیگر نیازی به «بش[^2]» هست؟
 چطور می توان کارهای تکراری را به کمک «بش» بطور خودکار انجام داد؟
 دستوری را نمیدانم، چطور کمک بگیرم؟
 
@@ -24,7 +24,7 @@ show_sidebar: false
 - دریافت اطلاعات مربوط به دستگاه
 - نحوه استفاده از راهنما
 - خوانش، ایجاد و تغییر محتوی پرونده ها
-- معرفی ابتدایی «اوک» [۵] و «سد» [۶]
+- معرفی ابتدایی نرم‌افزار‌های «اوک» [^3] و «سد» [^4]
 - مسیریابی، ساخت و نمایش پرونده ها در سیستم
 - تعریف متغیرها و معرفی متغیرهای ویژه
 - تعریف ساختارهای شرطی
@@ -32,7 +32,12 @@ show_sidebar: false
 
 کلام آخر: «اصلا به من چه!؟ من که برنامه نویس نیستم!»
 
+[^1] [Python](https://www.python.org/): a programming language that lets you work quickly and integrate systems more effectively.
+[^2] [GNU Bash](https://www.gnu.org/software/bash/): the GNU Project's shell, the _B_ourne _A_gain _SH_ell.
+[^3] [GNU awk](https://www.gnu.org/software/gawk/): a special-purpose programming language that makes it possible to handle simple data-reformatting jobs with just a few lines of code.
+[^4] [GNU sed](https://www.gnu.org/software/sed/): _s_tream _ed_itor is a non-interactive command-line text editor.
+
 **Resources:**
-- [Bash tutorial](https://www.aparat.com/v/LVSik)
-- [OAM talk](https://codeberg.org/pedramardakani/oam-talk)
+- [Bash tutorial video in Aparat](https://www.aparat.com/v/LVSik)
+- [Git repository on codeberg](https://codeberg.org/pedramardakani/oam-talk)
 - [POSIX power tools: basic operations on the command-line](https://gitlab.com/makhlaghi/smack-talks-iac/-/blob/master/smack-2-shell.md)


### PR DESCRIPTION
Fix minor typo in the 'index.md' homepage.

Add footnotes in 'presentations/2022/Working_in_Command-Line_Interface.md' and change the link names.