### PR TITLE
Fix footnote markdown syntax

### DIFF
--- a/presentations/2022/Working_in_Command-Line_Interface.md
+++ b/presentations/2022/Working_in_Command-Line_Interface.md
@@ -15,7 +15,7 @@ show_sidebar: false
 چرا با وجود پیشرفت بسیار گرافیک دستگاه ها، محیط خط فرمان فراموش نشده؟
 آیا واقعا کار در محیط گرافیکی سریعتر از یادآوری و تایپ کردن دستور است؟
 پوسته و بش چه هستند؟
-آیا با وجود «پایتون[^1]» دیگر نیازی به «بش[^2]» هست؟
+آیا با وجود «پایتون» [^1] دیگر نیازی به «بش» [^2] هست؟
 چطور می توان کارهای تکراری را به کمک «بش» بطور خودکار انجام داد؟
 دستوری را نمیدانم، چطور کمک بگیرم؟
 
@@ -32,10 +32,10 @@ show_sidebar: false
 
 کلام آخر: «اصلا به من چه!؟ من که برنامه نویس نیستم!»
 
-[^1] [Python](https://www.python.org/): a programming language that lets you work quickly and integrate systems more effectively.
-[^2] [GNU Bash](https://www.gnu.org/software/bash/): the GNU Project's shell, the _B_ourne _A_gain _SH_ell.
-[^3] [GNU awk](https://www.gnu.org/software/gawk/): a special-purpose programming language that makes it possible to handle simple data-reformatting jobs with just a few lines of code.
-[^4] [GNU sed](https://www.gnu.org/software/sed/): _s_tream _ed_itor is a non-interactive command-line text editor.
+[^1]: [Python](https://www.python.org/): a programming language that lets you work quickly and integrate systems more effectively.
+[^2]: [GNU Bash](https://www.gnu.org/software/bash/): the GNU Project's shell, the _B_ourne _A_gain _SH_ell.
+[^3]: [GNU awk](https://www.gnu.org/software/gawk/): a special-purpose programming language that makes it possible to handle simple data-reformatting jobs with just a few lines of code.
+[^4]: [GNU sed](https://www.gnu.org/software/sed/): _s_tream _ed_itor is a non-interactive command-line text editor.
 
 **Resources:**
 - [Bash tutorial video in Aparat](https://www.aparat.com/v/LVSik)


### PR DESCRIPTION
Add a semicolon ':' to footnote references, let's see if 'jekyll' understands this markdown syntax as github does.

For example, here is a footnote[^1].

[^1]: This should render just fine in the browser.